### PR TITLE
Replace rand() for random salt generation (CVE-2026-6659)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -35,6 +35,7 @@ my(%params) =
 	PL_FILES	=> {},
 	PREREQ_PM	=>
 	{
+		'Crypt::URandom'	=> 0,
 		'Digest::MD5'	=> 2.53,
 		'strict'		=> 0,
 		'warnings'		=> 0,

--- a/lib/Crypt/PasswdMD5.pm
+++ b/lib/Crypt/PasswdMD5.pm
@@ -3,6 +3,7 @@ package Crypt::PasswdMD5;
 use strict;
 use warnings;
 
+use Crypt::URandom qw(urandom);
 use Digest::MD5;
 use Encode;
 
@@ -40,7 +41,7 @@ sub random_md5_salt
 	# Sanity check.
 
 	$len  = $max_salt_length unless ( ($len >= 1) and ($len <= $max_salt_length) );
-	$salt .= substr($itoa64,int(rand(64)),1) for (1..$len);
+	$salt .= substr($itoa64,unpack("C",urandom(1))&0x3F,1) for (1..$len);
 
 	return $salt;
 

--- a/t/00.versions.t
+++ b/t/00.versions.t
@@ -9,6 +9,7 @@ use Crypt::PasswdMD5; # For the version #.
 
 use Test::More;
 
+use Crypt::URandom;
 use Digest::MD5;
 use strict;
 use warnings;
@@ -19,6 +20,7 @@ pass('All external modules loaded');
 
 my(@modules) = qw
 /
+	Crypt::URandom
 	Digest::MD5
 	strict
 	warnings


### PR DESCRIPTION
Replace use of the cryptographically weak `rand()` function with the much stronger `Crypt::URandom::urandom()` function in sub `random_md5_salt`.

See also:
https://security.metacpan.org/docs/guides/random-data-for-security.html